### PR TITLE
io-package.json: Fixup swap_used calculation.

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -164,7 +164,7 @@
             "swap_used": {
                 "command": "cat /proc/meminfo",
                 "regexp": "SwapFree:\\s+(\\d+)",
-                "post": "rpi.swap_total - ($1/1024)",
+                "post": "(rpi.swap_total - $1)/1024",
                 "multiline": true
             }
         },


### PR DESCRIPTION
At least on my system, it seems that rpi.swap_total is used in the calculation before the "post" scaling is applied. 
Thus, subtracting first and only then dividing by 1024 fixes things here.